### PR TITLE
Convert existing workflows to be reusable

### DIFF
--- a/.github/workflows/apply_recommendations.yml
+++ b/.github/workflows/apply_recommendations.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   autoapply:
     runs-on: ubuntu-latest
-    name: Apply Adaptive Metrics recommendations
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/apply_recommendations.yml
+++ b/.github/workflows/apply_recommendations.yml
@@ -1,13 +1,14 @@
 name: Apply Adaptive Metrics recommendations
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'recommendations.json'
-      - 'main.tf'
+  workflow_call:
+    inputs:
+      grafana_am_api_url:
+        required: true
+        type: string
+    secrets:
+      grafana_am_api_key:
+        required: true
 
 jobs:
   autoapply:
@@ -17,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GRAFANA_AM_API_URL: ${{ vars.grafana_am_api_url }}
+      GRAFANA_AM_API_URL: ${{ inputs.grafana_am_api_url }}
       GRAFANA_AM_API_KEY: ${{ secrets.grafana_am_api_key }}
     steps:
       - name: Checkout

--- a/.github/workflows/do_apply_recommendations.yml
+++ b/.github/workflows/do_apply_recommendations.yml
@@ -1,0 +1,19 @@
+name: Apply Adaptive Metrics recommendations
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'recommendations.json'
+      - 'main.tf'
+
+jobs:
+  do-autoapply:
+    name: Apply Adaptive Metrics recommendations
+    uses: ./.github/workflows/apply_recommendations.yml
+    with:
+      grafana_am_api_url: ${{ vars.grafana_am_api_url }}
+    secrets:
+      grafana_am_api_key: ${{ secrets.grafana_am_api_key }}

--- a/.github/workflows/do_apply_recommendations.yml
+++ b/.github/workflows/do_apply_recommendations.yml
@@ -1,4 +1,4 @@
-name: Apply Adaptive Metrics recommendations
+name: Triggered apply of Adaptive Metrics recommendations
 
 on:
   workflow_dispatch:
@@ -11,7 +11,6 @@ on:
 
 jobs:
   do-autoapply:
-    name: Apply Adaptive Metrics recommendations
     uses: ./.github/workflows/apply_recommendations.yml
     with:
       grafana_am_api_url: ${{ vars.grafana_am_api_url }}

--- a/.github/workflows/do_pull_recommendations.yml
+++ b/.github/workflows/do_pull_recommendations.yml
@@ -1,4 +1,4 @@
-name: Pull Adaptive Metrics recommendations
+name: Scheduled refresh of Adaptive Metrics recommendations
 
 on:
   workflow_dispatch:
@@ -7,7 +7,6 @@ on:
 
 jobs:
   do-autoapply:
-    name: Pull the latest Adaptive Metrics recommendations
     uses: ./.github/workflows/pull_recommendations.yml
     with:
       grafana_am_api_url: ${{ vars.grafana_am_api_url }}

--- a/.github/workflows/do_pull_recommendations.yml
+++ b/.github/workflows/do_pull_recommendations.yml
@@ -1,0 +1,16 @@
+name: Pull Adaptive Metrics recommendations
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1-5'
+
+jobs:
+  do-autoapply:
+    name: Pull the latest Adaptive Metrics recommendations
+    uses: ./.github/workflows/pull_recommendations.yml
+    with:
+      grafana_am_api_url: ${{ vars.grafana_am_api_url }}
+      grafana_am_automerge_enabled: ${{ vars.grafana_am_automerge_enabled == 'true'}}
+    secrets:
+      grafana_am_api_key: ${{ secrets.grafana_am_api_key }}

--- a/.github/workflows/pull_recommendations.yml
+++ b/.github/workflows/pull_recommendations.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   autoapply:
     runs-on: ubuntu-latest
-    name: Pull the latest Adaptive Metrics recommendations
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pull_recommendations.yml
+++ b/.github/workflows/pull_recommendations.yml
@@ -1,9 +1,16 @@
 name: Pull Adaptive Metrics recommendations
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 4 * * 1-5'
+  workflow_call:
+    inputs:
+      grafana_am_api_url:
+        required: true
+        type: string
+      grafana_am_automerge_enabled:
+        type: boolean
+    secrets:
+      grafana_am_api_key:
+        required: true
 
 jobs:
   autoapply:
@@ -13,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GRAFANA_AM_API_URL: ${{ vars.grafana_am_api_url }}
+      GRAFANA_AM_API_URL: ${{ inputs.grafana_am_api_url }}
       GRAFANA_AM_API_KEY: ${{ secrets.grafana_am_api_key }}
     steps:
       - name: Checkout
@@ -29,7 +36,7 @@ jobs:
           commit-message: Scheduled refresh of the latest recommendations.
           body: Scheduled refresh of the latest recommendations.
       - name: Enable pull request auto-merge
-        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && vars.grafana_am_automerge_enabled == 'true' }}
+        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && inputs.grafana_am_automerge_enabled }}
         run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR expands the existing `pull_recommendations.yml` and `apply_recommendations.yml` workflows to be reusable, as well as moving the scheduled triggers of the existing workflows into `do_pull_recommendations.yml` and `do_apply_recommendations.yml`, respectively.

This allows `pull_recommendations.yml` and `apply_recommendations.yml` to be called from other repositories.