### PR TITLE
Fix auto-apply PR not triggering the GH action

### DIFF
--- a/.github/workflows/pull_recommendations.yml
+++ b/.github/workflows/pull_recommendations.yml
@@ -35,7 +35,7 @@ jobs:
           commit-message: Scheduled refresh of the latest recommendations.
           body: Scheduled refresh of the latest recommendations.
       - name: Enable pull request auto-merge
-        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && inputs.grafana_am_automerge_enabled }}
+        if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && env.GH_TOKEN != '' }}
         run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.automerge_pat }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can also set the pull request to merge automatically.
 
 ## Automatically apply recommendations
 
-Set up a GitHub Action to automatically apply Adaptive Metrics recommendations in Grafana Cloud.
+Create a new repository using this one as a template to automatically apply Adaptive Metrics recommendations in Grafana Cloud.
 
 1. Create a new repository by navigating to "Use this template" → "Create a new repository" at the top-right of the repository page in GitHub.
 
@@ -44,9 +44,13 @@ After you merge this pull request, the workflow automatically creates the corres
 
 ## (Optional) Automatically merge rules
 
-You can enable auto-merge mode to skip the manual pull request review and merge processes. To automatically merge the pull request containing the latest set of aggregation rules, define the following variable in your repository:
+You can enable auto-merge mode to skip the manual pull request review and merge processes.
 
-    grafana_am_automerge_enabled = true
+1. Create a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). The personal access token should have access to the repo and read/write permissions for "Pull Requests" and "Contents" enabled.
+
+2. Go to "Settings" → "Secrets and variables" → "Actions" → "New repository secret" and add the following secret to the new repository:
+
+    - `automerge_pat`: This is the personal access token you created in the previous step.
 
 ## Control your recommendations
 


### PR DESCRIPTION
It's not sufficient to use `github.token` when creating the auto-merge pull request because [that token will not trigger new workflow runs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

Instead, the user will need to create a personal access token and add it as a secret.