### PR TITLE
Small changes for re-using internally

### DIFF
--- a/apply_recommendations/action.yml
+++ b/apply_recommendations/action.yml
@@ -3,3 +3,7 @@ description: 'Apply your Adaptive Metrics recommendations.'
 runs:
     using: 'docker'
     image: 'Dockerfile'
+inputs:
+  working-dir:
+    default: '.'
+    description: 'The directory to run the apply in.'

--- a/apply_recommendations/action.yml
+++ b/apply_recommendations/action.yml
@@ -5,5 +5,5 @@ runs:
     image: 'Dockerfile'
 inputs:
   working-dir:
-    default: '.'
+    default: './'
     description: 'The directory to run the apply in.'

--- a/apply_recommendations/action.yml
+++ b/apply_recommendations/action.yml
@@ -7,3 +7,6 @@ inputs:
   working-dir:
     default: './'
     description: 'The directory to run the apply in.'
+  dry-run:
+    default: 'false'
+    description: 'Whether to apply the recommendations or just print tf plan output.'

--- a/apply_recommendations/cmd/apply/main.go
+++ b/apply_recommendations/cmd/apply/main.go
@@ -24,7 +24,12 @@ func main() {
 		}
 	}
 
-	workingDir := flag.String("working-dir", os.Getenv("INPUT_WORKING-DIR"), "The path to the working directory.")
+	defaultWorkingDir := "./"
+	if workingDirEnvVar := os.Getenv("INPUT_WORKING-DIR"); workingDirEnvVar != "" {
+		defaultWorkingDir = workingDirEnvVar
+	}
+
+	workingDir := flag.String("working-dir", defaultWorkingDir, "The path to the working directory.")
 	dryRun := flag.Bool("dry-run", defaultDryRun, "dry run; run terraform plan instead of terraform apply")
 	flag.Parse()
 

--- a/apply_recommendations/cmd/apply/main.go
+++ b/apply_recommendations/cmd/apply/main.go
@@ -32,6 +32,9 @@ func main() {
 		log.Fatalf("error running NewTerraform: %s", err)
 	}
 
+	tf.SetStderr(os.Stderr)
+	tf.SetStdout(os.Stdout)
+
 	err = tf.Init(context.Background(), tfexec.Upgrade(true))
 	if err != nil {
 		log.Fatalf("error running Init: %s", err)

--- a/apply_recommendations/cmd/apply/main.go
+++ b/apply_recommendations/cmd/apply/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	workingDir := flag.String("working-dir", "./", "path to working directory")
+	workingDir := flag.String("working-dir", os.Getenv("INPUT_WORKING-DIR"), "The path to the working directory.")
 	dryRun := flag.Bool("dry-run", false, "dry run; run terraform plan instead of terraform apply")
 	flag.Parse()
 

--- a/apply_recommendations/cmd/apply/main.go
+++ b/apply_recommendations/cmd/apply/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/product"
@@ -13,8 +14,18 @@ import (
 )
 
 func main() {
+
+	defaultDryRun := false
+	if dryRunEnvVar := os.Getenv("INPUT_DRY-RUN"); dryRunEnvVar != "" {
+		var err error
+		defaultDryRun, err = strconv.ParseBool(dryRunEnvVar)
+		if err != nil {
+			log.Fatalf("error parsing INPUT_DRY-RUN: %s", err)
+		}
+	}
+
 	workingDir := flag.String("working-dir", os.Getenv("INPUT_WORKING-DIR"), "The path to the working directory.")
-	dryRun := flag.Bool("dry-run", false, "dry run; run terraform plan instead of terraform apply")
+	dryRun := flag.Bool("dry-run", defaultDryRun, "dry run; run terraform plan instead of terraform apply")
 	flag.Parse()
 
 	installer := &releases.ExactVersion{

--- a/pull_recommendations/action.yml
+++ b/pull_recommendations/action.yml
@@ -5,5 +5,5 @@ runs:
     image: 'Dockerfile'
 inputs:
   working-dir:
-    default: '.'
+    default: './'
     description: 'The directory to place the recommendations in.'

--- a/pull_recommendations/action.yml
+++ b/pull_recommendations/action.yml
@@ -3,3 +3,7 @@ description: 'Pull your latest Adaptive Metrics recommendations.'
 runs:
     using: 'docker'
     image: 'Dockerfile'
+inputs:
+  working-dir:
+    default: '.'
+    description: 'The directory to place the recommendations in.'

--- a/pull_recommendations/cmd/pull/main.go
+++ b/pull_recommendations/cmd/pull/main.go
@@ -53,12 +53,12 @@ func main() {
 		// Sort exact match rules first, then sort by metric name.
 		slices.SortStableFunc(recs, func(a, b internal.Recommendation) int {
 			// If both are exact matches, sort by metric name.
-			if a.MatchType == "exact" && b.MatchType == "exact" {
+			if isExactMatch(a) && isExactMatch(b) {
 				return strings.Compare(a.Metric, b.Metric)
 			}
 			// Otherwise sort exact matches first
 			if a.MatchType != b.MatchType {
-				if a.MatchType == "exact" {
+				if isExactMatch(a) {
 					return -1
 				}
 				return 1
@@ -80,6 +80,10 @@ func main() {
 			log.Fatalf("failed to write recommendations for segment %s: %v", segment.Name, err)
 		}
 	}
+}
+
+func isExactMatch(rule internal.Recommendation) bool {
+	return rule.MatchType == "exact" || rule.MatchType == ""
 }
 
 func mustGetEnv(key string) string {

--- a/pull_recommendations/cmd/pull/main.go
+++ b/pull_recommendations/cmd/pull/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	workingDir := flag.String("working-dir", "./", "The path to the working directory.")
+	workingDir := flag.String("working-dir", os.Getenv("INPUT_WORKING-DIR"), "The path to the working directory.")
 	userAgent := flag.String("user-agent", "gh-action-autoapply", "The user-agent to use when making requests against the API.")
 
 	writeSegments := flag.Bool("write-segments", false, "Optionally write a segments.json file to disk.")

--- a/pull_recommendations/cmd/pull/main.go
+++ b/pull_recommendations/cmd/pull/main.go
@@ -15,7 +15,12 @@ import (
 )
 
 func main() {
-	workingDir := flag.String("working-dir", os.Getenv("INPUT_WORKING-DIR"), "The path to the working directory.")
+	defaultWorkingDir := "./"
+	if workingDirEnvVar := os.Getenv("INPUT_WORKING-DIR"); workingDirEnvVar != "" {
+		defaultWorkingDir = workingDirEnvVar
+	}
+
+	workingDir := flag.String("working-dir", defaultWorkingDir, "The path to the working directory.")
 	userAgent := flag.String("user-agent", "gh-action-autoapply", "The user-agent to use when making requests against the API.")
 
 	writeSegments := flag.Bool("write-segments", false, "Optionally write a segments.json file to disk.")


### PR DESCRIPTION
This PR collects a few changes that were convenient to dogfood this repo in my personal stack.

1. Adds support for `working-dir` in the action inputs
2. Adds support for `dry-run` in the apply action
3. Adds logs in the pull action to show what files are being touched
4. Fixes rule sorting to avoid changing semantics
5. Sets the terraform apply / plan output to be visible in the action logs