### PR TITLE
Fetch segments instead of reading from disk

### DIFF
--- a/docker/cmd/adaptive-metrics/apply.go
+++ b/docker/cmd/adaptive-metrics/apply.go
@@ -47,7 +47,7 @@ func apply(args []string) {
 
 	c := internal.NewClient(&http.Client{}, *userAgent, apiURL, apiKey)
 
-	segments, err := readJSONFile[[]internal.Segment]("segments.json")
+	segments, err := c.FetchSegments()
 	if err != nil {
 		log.Fatalf("failed to read segments: %v", err)
 	}

--- a/docker/cmd/adaptive-metrics/pull.go
+++ b/docker/cmd/adaptive-metrics/pull.go
@@ -23,7 +23,7 @@ func pull(args []string) {
 	flags := flag.NewFlagSet("pull", flag.ExitOnError)
 	workingDir := flags.String("working-dir", defaultWorkingDir, "The path to the working directory.")
 	userAgent := flags.String("user-agent", "gh-action-autoapply", "The user-agent to use when making requests against the API.")
-	writeSegments := flags.Bool("write-segments", true, "Optionally write a segments.json file to disk.")
+	writeSegments := flags.Bool("write-segments", false, "Optionally write a segments.json file to disk.")
 
 	err := flags.Parse(args)
 	if err != nil {


### PR DESCRIPTION
In order to apply rules from potentially different tenants, we have to tolerate segment ids that change. This PR pulls the latest segments from storage instead of relying on the on-disk format.