### PR TITLE
Don't print summaries close to max limit

### DIFF
--- a/docker/cmd/adaptive-metrics/apply.go
+++ b/docker/cmd/adaptive-metrics/apply.go
@@ -82,6 +82,14 @@ func apply(args []string) {
 	}
 
 	if totalChanges > 0 {
+
+		// Max summary size is 1MB, if we're close, then just write a summary.
+		if stepSummary.Len() > 900e3 {
+			stepSummary.Reset()
+
+			fmt.Fprintf(stepSummary, "Skipping detailed diff because it's too large (%d bytes)\n\n", stepSummary.Len())
+		}
+
 		fmt.Fprintln(stepSummary, "#### Summary")
 		fmt.Fprintf(stepSummary, "- %d changes detected in aggregation rules\n", totalChanges)
 		fmt.Fprintf(stepSummary, "- %d modified segments\n", changedSegments)


### PR DESCRIPTION
Github has a max size for the step summaries of 1MB. This PR skips writing it if it's close to that limit. The end result is that human-authored PRs should still get a nice diff, but some machine PRs will not. That's ok because they aren't expected to be reviewed anyway.

![Screenshot 2024-08-22 at 2 25 53 PM](https://github.com/user-attachments/assets/c06ce460-4052-4546-aa2e-4343061012ee)
