### PR TITLE
Set the `managed_by` field on update and remove from diffs

### DIFF
--- a/docker/action.yml
+++ b/docker/action.yml
@@ -10,3 +10,6 @@ inputs:
   dry-run:
     default: 'false'
     description: 'Whether to apply the recommendations or just print tf plan output.'
+  managed-by:
+    default: 'gh-action-autoapply'
+    description: 'The tag used to set the managed_by label on applied rules.'

--- a/docker/cmd/adaptive-metrics/github_action.go
+++ b/docker/cmd/adaptive-metrics/github_action.go
@@ -21,7 +21,7 @@ func newGithubActionWorkflowCommands() (*githubActionWorkflowCommands, error) {
 		return nil, err
 	}
 
-	summaryFile, err := os.OpenFile(os.Getenv("GITHUB_STEP_SUMMARY"), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	summaryFile, err := os.OpenFile(os.Getenv("GITHUB_STEP_SUMMARY"), os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/cmd/adaptive-metrics/pull.go
+++ b/docker/cmd/adaptive-metrics/pull.go
@@ -76,6 +76,12 @@ func pull(args []string) {
 			return 0
 		})
 
+		// Strip the managed_by field from the recommendations. This adds unnecessary noise to the files, and is overwritten when applying the rules anyway.
+		for i, r := range recs {
+			r.ManagedBy = ""
+			recs[i] = r
+		}
+
 		// Write the recommendations to a file.
 		var filename string
 		if segment == internal.DefaultSegment {


### PR DESCRIPTION
This PR adds an input to the apply step called `managed-by`. This is used to set the `managed_by` field on all rules applied by the tool, similar to the terraform provider.

I've also fixed a few minor issues:
* Truncate GITHUB_STEP_SUMMARY, as there can only be one per step and it was making local debugging difficult.
* Stripping managed_by from the file output, since it's useless noise and will be overwritten anyway.
* Fixed incorrect reporting of step summary length when it nears the limit of 1MB
* Added missing `close` call for the github output