### PR TITLE
Preview cardinality changes in `pull` output

### DIFF
--- a/docker/cmd/adaptive-metrics/github_action.go
+++ b/docker/cmd/adaptive-metrics/github_action.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 type githubActionWorkflowCommands struct {
@@ -45,6 +46,8 @@ func (c *githubActionWorkflowCommands) writeOutput(name, value string) error {
 	if c == nil {
 		return nil
 	}
+
+	name = strings.ReplaceAll(name, " ", "_")
 
 	_, err := fmt.Fprintf(c.outputFile, "%s=%s\n", name, value)
 	return err

--- a/docker/internal/models.go
+++ b/docker/internal/models.go
@@ -17,7 +17,7 @@ type Segment struct {
 	FallbackToDefault bool   `json:"fallback_to_default,omitempty"`
 }
 
-type Recommendation struct {
+type RuleData struct {
 	Metric    string `json:"metric" yaml:"metric"`
 	MatchType string `json:"match_type,omitempty" yaml:"match_type,omitempty"`
 
@@ -32,6 +32,10 @@ type Recommendation struct {
 	Ingest bool `json:"ingest,omitempty" yaml:"ingest,omitempty"`
 
 	ManagedBy string `json:"managed_by,omitempty"`
+}
+
+type Recommendation struct {
+	RuleData
 
 	RecommendedAction  string `json:"recommended_action,omitempty"`
 	UsagesInRules      int    `json:"usages_in_rules,omitempty"`
@@ -39,7 +43,20 @@ type Recommendation struct {
 	UsagesInDashboards int    `json:"usages_in_dashboards,omitempty"`
 
 	// Used when recommended action is "add"
-	KeptLabels                   []string `json:"kept_labels,omitempty"`
-	TotalSeriesAfterAggregation  int      `json:"total_series_after_aggregation,omitempty"`
-	TotalSeriesBeforeAggregation int      `json:"total_series_before_aggregation,omitempty"`
+	KeptLabels []string `json:"kept_labels,omitempty"`
+
+	RawSeriesCount         int `json:"raw_series_count,omitempty"`         // Number of series the client is sending.
+	CurrentSeriesCount     int `json:"current_series_count,omitempty"`     // Number of series stored in the database.
+	RecommendedSeriesCount int `json:"recommended_series_count,omitempty"` // Number of series after applying the recommendation.
+}
+
+func ConvertVerboseToRules(recs []Recommendation) []RuleData {
+	rules := make([]RuleData, 0, len(recs))
+	for _, rec := range recs {
+		if rec.RecommendedAction == "remove" {
+			continue
+		}
+		rules = append(rules, rec.RuleData)
+	}
+	return rules
 }


### PR DESCRIPTION
This PR adds additional output to the `pull` action. Specifically, it will now generate github action outputs for the total series count and series count change in each segment.

It will also generate a handy summary in the form of a table. This makes it easier to review previous recommendation pulls to audit what has changed in terms of series count.

Example:

## Segment "default"
### Series Change
Total series change: -23446
Total series: 27854
Percentage change: -84.17%
| Metric | Action | Series Change |
|--------|--------|---------------|
| traefik_service_requests_total | add | -2 |
| traefik_service_request_duration_seconds_sum | add | -3 |
| kubelet_running_containers | add | -6 |
| kubelet_pod_worker_duration_seconds_count | add | -6 |
| prometheus_target_scrapes_sample_out_of_bounds_total | add | -8 |
| prometheus_target_scrapes_sample_out_of_order_total | add | -8 |
| prometheus_target_scrapes_sample_duplicate_timestamp_total | add | -8 |
| prometheus_target_scrapes_exceeded_sample_limit_total | add | -8 |
| http_server_request_body_size_bytes_sum | add | -17 |
| http_server_request_duration_seconds_sum | add | -17 |
| http_server_request_duration_seconds_count | add | -17 |
| http_server_request_body_size_bytes_count | add | -17 |
| grafana_mimir_top_cardinality | add | -19 |
| volume_manager_total_volumes | add | -30 |
| node_filesystem_free_bytes | add | -59 |
| node_filesystem_device_error | add | -59 |
| container_blkio_device_usage_total | add | -72 |
| http_server_request_body_size_bytes_bucket | add | -187 |
| http_server_request_duration_seconds_bucket | add | -272 |
| homeassistant_state_change_created | add | -339 |
| homeassistant_last_updated_time_seconds | add | -339 |
| homeassistant_entity_available | add | -339 |
| homeassistant_state_change_total | add | -383 |
| http_client_request_duration_seconds_sum | add | -442 |
| http_client_request_body_size_bytes_sum | add | -442 |
| http_client_request_duration_seconds_count | add | -443 |
| http_client_request_body_size_bytes_count | add | -443 |
| etcd_request_duration_seconds_sum | add | -537 |
| etcd_request_duration_seconds_count | add | -537 |
| http_client_request_body_size_bytes_bucket | add | -4867 |
| etcd_request_duration_seconds_bucket | add | -6444 |
| http_client_request_duration_seconds_bucket | add | -7076 |
