### PR TITLE
fix the vulnerabilities reported by zizmor.

### DIFF
--- a/.github/workflows/apply_recommendations.yml
+++ b/.github/workflows/apply_recommendations.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Apply recommendations
         uses: ./apply_recommendations
       - name: Commit and push changes

--- a/.github/workflows/do_apply_recommendations.yml
+++ b/.github/workflows/do_apply_recommendations.yml
@@ -10,6 +10,10 @@ on:
       - 'recommendations-*.json'
       - 'main.tf'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   do-autoapply:
     uses: ./.github/workflows/apply_recommendations.yml

--- a/.github/workflows/do_pull_recommendations.yml
+++ b/.github/workflows/do_pull_recommendations.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 4 * * 1-5'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   do-autoapply:
     uses: ./.github/workflows/pull_recommendations.yml

--- a/.github/workflows/pull_recommendations.yml
+++ b/.github/workflows/pull_recommendations.yml
@@ -23,18 +23,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Pull recommendations
         uses: ./pull_recommendations
         id: pull_recommendations
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.0.0
         with:
           title: Scheduled refresh of the latest recommendations.
           commit-message: Scheduled refresh of the latest recommendations.
           body: Scheduled refresh of the latest recommendations.
       - name: Enable pull request auto-merge
         if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && env.GH_TOKEN != '' }}
-        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        run: |
+          # Validate PR number is a positive integer
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Error: Invalid pull request number"
+            exit 1
+          fi
+          gh pr merge --merge --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.automerge_pat }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
```shell
❯ zizmor adaptive-metrics-autoapply
 INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
 INFO zizmor: skipping ref-confusion: can't run without a GitHub API token
 INFO zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/.github/workflows/apply_recommendations.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/.github/workflows/do_apply_recommendations.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/.github/workflows/do_pull_recommendations.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/.github/workflows/pull_recommendations.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/apply_recommendations/action.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/docker/action.yml
 INFO audit: zizmor: 🌈 completed adaptive-metrics-autoapply/pull_recommendations/action.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> adaptive-metrics-autoapply/.github/workflows/apply_recommendations.yml:23:9
   |
23 |         - name: Checkout
   |  _________-
24 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> adaptive-metrics-autoapply/.github/workflows/do_apply_recommendations.yml:14:3
   |
14 | /   do-autoapply:
15 | |     uses: ./.github/workflows/apply_recommendations.yml
...  |
18 | |     secrets:
19 | |       grafana_am_api_key: ${{ secrets.grafana_am_api_key }}
   | |                                                            -
   | |____________________________________________________________|
   |                                                              this job
   |                                                              default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> adaptive-metrics-autoapply/.github/workflows/do_pull_recommendations.yml:9:3
   |
 9 | /   do-autoapply:
10 | |     uses: ./.github/workflows/pull_recommendations.yml
...  |
14 | |       grafana_am_api_key: ${{ secrets.grafana_am_api_key }}
15 | |       automerge_pat: ${{ secrets.automerge_pat }}
   | |                                                  -
   | |__________________________________________________|
   |                                                    this job
   |                                                    default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> adaptive-metrics-autoapply/.github/workflows/pull_recommendations.yml:24:9
   |
24 |         - name: Checkout
   |  _________-
25 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> adaptive-metrics-autoapply/.github/workflows/pull_recommendations.yml:36:9
   |
36 |       - name: Enable pull request auto-merge
   |         ------------------------------------ info: this step
37 |         if: ${{ steps.cpr.outputs.pull-request-operation == 'created' && env.GH_TOKEN != '' }}
38 |         run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
   |         ------------------------------------------------------------------------------ info: steps.cpr.outputs.pull-request-number may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> adaptive-metrics-autoapply/.github/workflows/pull_recommendations.yml:31:9
   |
31 |         uses: peter-evans/create-pull-request@v6
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

10 findings (4 suppressed): 0 unknown, 1 informational, 0 low, 4 medium, 1 high
```