### PR TITLE
support managed-by parameter in apply_recommendations action

### DIFF
--- a/apply_recommendations/action.yml
+++ b/apply_recommendations/action.yml
@@ -12,6 +12,9 @@ inputs:
   dry-run:
     default: 'false'
     description: 'Whether to apply the recommendations or just print a summary of changes.'
+  managed-by:
+    default: 'gh-action-autoapply'
+    description: 'The tag used to set the managed_by label on applied rules.'
 outputs:
   changes-detected:
     description: 'Whether any changes were detected in the recommendations.'


### PR DESCRIPTION
To fix the problem showing up in the `Annotations` of the GitHub action runs, [for example here](https://github.com/grafana/deployment_tools/actions/runs/15139279120).

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/effe8a36-a456-48af-89b7-3a23936c60be" />
