### PR TITLE
ci: disable dry-run for cleanup-branches workflow

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1
         with:
-          dry-run: "true"
+          dry-run: "false"
 


### PR DESCRIPTION
The dry-run was validated — branches listed for deletion look correct. This disables dry-run so stale branches actually get cleaned up on the weekly schedule.